### PR TITLE
bug client release called on already released clients

### DIFF
--- a/server/src/dao/gamesDAO.js
+++ b/server/src/dao/gamesDAO.js
@@ -66,75 +66,59 @@ export default class GamesDAO {
   }
   static async getGames() {
     try {
-      client = await poolRef.connect();
-      const games = await client.query(
+      const games = await poolRef.query(
         `${selectAndExpandGames} ${orderByIdDesc}`
       );
       return games.rows;
     } catch (err) {
       console.error(err.message);
       return [];
-    } finally {
-      client.release();
     }
   }
   static async getGameById(gameId) {
     try {
-      client = await poolRef.connect();
-      const gameById = await client.query(
+      const gameById = await poolRef.query(
         `${selectAndExpandGames} ${whereGameId}`,
         [gameId]
       );
       return gameById.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 
   static async getTournamentGamesById(gameId) {
     try {
-      client = await poolRef.connect();
-      const data = await client.query(
+      const data = await poolRef.query(
         `${selectAndExpandGames} ${whereTournamentId}`,
         [gameId]
       );
       return data.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getRecentGamesByPlayerId(playerId) {
     try {
-      client = await poolRef.connect();
-      const data = await client.query(
+      const data = await poolRef.query(
         `${selectAndExpandGames} ${wherePlayerId} ${orderByDateDesc} ${limitByRecent}`,
         [playerId, playerId]
       );
       return data.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async postNewGame(details) {
     try {
-      client = await poolRef.connect();
-      const createNewGame = await client.query(insertNewGame, details);
+      const createNewGame = await poolRef.query(insertNewGame, details);
       return createNewGame;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async patchGame(homeCupsLeft, awayCupsLeft, table, gameId) {
     try {
-      client = await poolRef.connect();
       const lockOnWin =
         homeCupsLeft === 0 || awayCupsLeft === 0 ? 'locked=true,' : '';
       const updateSql = `UPDATE ${process.env.DATABASE}.games 
@@ -144,7 +128,7 @@ export default class GamesDAO {
         game_table=$3
         WHERE ${process.env.DATABASE}.games.id=$4
         `;
-      const updateGame = await client.query(updateSql, [
+      const updateGame = await poolRef.query(updateSql, [
         homeCupsLeft,
         awayCupsLeft,
         table,
@@ -153,8 +137,6 @@ export default class GamesDAO {
       return updateGame;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/newsDAO.js
+++ b/server/src/dao/newsDAO.js
@@ -38,28 +38,22 @@ export default class NewsDAO {
   }
   static async getNews() {
     try {
-      client = await poolRef.connect();
-      const news = await client.query(
+      const news = await poolRef.query(
         `${selectNewsAndUsers} ${whereApproved} ${orderByDesc}`
       );
       return news.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getNewsById(newsId) {
     try {
-      client = await poolRef.connect();
-      const newsById = await client.query(`${selectNewsAndUsers} ${whereId}`, [
+      const newsById = await poolRef.query(`${selectNewsAndUsers} ${whereId}`, [
         newsId,
       ]);
       return newsById.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/nicknamesDAO.js
+++ b/server/src/dao/nicknamesDAO.js
@@ -25,26 +25,20 @@ export default class NicknamesDAO {
   }
   static async getNicknames() {
     try {
-      client = await poolRef.connect();
-      const nicknames = await client.query(selectNicks);
+      const nicknames = await poolRef.query(selectNicks);
       return nicknames.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getNicknameOfPlayerId(playerId) {
     try {
-      client = await poolRef.connect();
-      const nicknames = await client.query(`${selectNicks} ${wherePlayerId}`, [
+      const nicknames = await poolRef.query(`${selectNicks} ${wherePlayerId}`, [
         playerId,
       ]);
       return nicknames.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/overviewDAO.js
+++ b/server/src/dao/overviewDAO.js
@@ -44,8 +44,7 @@ export default class OverviewDAO {
   }
   static async getOverviewByPlayerId(playerId) {
     try {
-      client = await poolRef.connect();
-      const playerOverview = await client.query(`${collate}`, [
+      const playerOverview = await poolRef.query(`${collate}`, [
         playerId,
         playerId,
         playerId,
@@ -59,8 +58,6 @@ export default class OverviewDAO {
       return playerOverview.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/playersDAO.js
+++ b/server/src/dao/playersDAO.js
@@ -30,33 +30,28 @@ export default class PlayersDAO {
   }
   static async getPlayers() {
     try {
-      client = await poolRef.connect();
-      const players = await client.query(allPlayers);
+      const players = await poolRef.query(allPlayers);
       return players.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getPlayerById(playerId) {
     try {
-      client = await poolRef.connect();
-      const player = await client.query(`${playerDetails} ${wherePlayerId}`, [
+      const player = await poolRef.query(`${playerDetails} ${wherePlayerId}`, [
         playerId,
       ]);
       return player.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async postNewPlayer(playerName) {
     try {
-      client = await poolRef.connect();
       const values = [playerName];
-      const checkPlayers = await client.query(selectPlayerByName, [playerName]);
+      const checkPlayers = await poolRef.query(selectPlayerByName, [
+        playerName,
+      ]);
       if (checkPlayers.rowCount > 0) {
         //user already exists with this username
         const playerAlreadyExists = new Error(
@@ -64,7 +59,7 @@ export default class PlayersDAO {
         );
         return playerAlreadyExists;
       } else {
-        const createNewPlayer = client.query(insertNewPlayer, values);
+        const createNewPlayer = poolRef.query(insertNewPlayer, values);
         if (createNewPlayer) {
           return createNewPlayer;
         } else {
@@ -74,8 +69,6 @@ export default class PlayersDAO {
       }
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/recordsDAO.js
+++ b/server/src/dao/recordsDAO.js
@@ -41,56 +41,44 @@ export default class RecordsDAO {
   }
   static async getCurrentRecords() {
     try {
-      client = await poolRef.connect();
-      const records = await client.query(
+      const records = await poolRef.query(
         `${selectRecordsAndPlayers} ${whereCurrentRecord} ${orderByDesc}`
       );
       return records.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getAllRecords() {
     try {
-      client = await poolRef.connect();
-      const allRecords = await client.query(
+      const allRecords = await poolRef.query(
         `${selectRecordsAndPlayers} ${orderByDesc}`
       );
       return allRecords.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getRecordsByPlayerId(playerId) {
     try {
-      client = await poolRef.connect();
-      const records = await client.query(
+      const records = await poolRef.query(
         `${selectRecordsAndPlayers} ${wherePlayerId}`,
         [playerId]
       );
       return records.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getRecordsByTypeId(typeId) {
     try {
-      client = await poolRef.connect();
-      const recordsByType = await client.query(
+      const recordsByType = await poolRef.query(
         `${selectRecordsAndPlayers} ${whereRecordTypeId} ${orderByDesc}`,
         [typeId]
       );
       return recordsByType.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/tournamentsDAO.js
+++ b/server/src/dao/tournamentsDAO.js
@@ -46,42 +46,33 @@ export default class TournamentsDAO {
   }
   static async getTournaments() {
     try {
-      client = await poolRef.connect();
-      const tournaments = await client.query(
+      const tournaments = await poolRef.query(
         `${selectTournaments} ${orderByDate}`
       );
       return tournaments.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getRecentTournaments() {
     try {
-      client = await poolRef.connect();
-      const tournaments = await client.query(
+      const tournaments = await poolRef.query(
         `${selectTournaments} ${orderByDate} ${limitByRecent}`
       );
       return tournaments.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async getTournamentById(tournamentId) {
     try {
-      client = await poolRef.connect();
-      const tournaments = await client.query(
+      const tournaments = await poolRef.query(
         `${selectTournaments} ${whereId}`,
         [tournamentId]
       );
       return tournaments.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/userPreferencesDAO.js
+++ b/server/src/dao/userPreferencesDAO.js
@@ -24,27 +24,23 @@ export default class UserPreferencesDAO {
   }
   static async getUserPreferences(userId) {
     try {
-      client = await poolRef.connect();
-      const preferences = await client.query(selectUserPreferences, [userId]);
+      const preferences = await poolRef.query(selectUserPreferences, [userId]);
       return preferences.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
   static async postUserPreferences(userId, prefs) {
     try {
-      client = await poolRef.connect();
       // query is different depending if user profile exists
-      const userPreferences = await client.query(`${selectUserPreferences}`, [
+      const userPreferences = await poolRef.query(`${selectUserPreferences}`, [
         userId,
       ]);
       if (userPreferences.rowCount > 0) {
         const update = `UPDATE ${process.env.DATABASE}.preferences
         SET avatar_link=$1
         WHERE user_id=$2`;
-        const updateUserPreferences = await client.query(update, [
+        const updateUserPreferences = await poolRef.query(update, [
           prefs,
           userId,
         ]);
@@ -52,7 +48,7 @@ export default class UserPreferencesDAO {
         return updateUserPreferences.rows;
       } else {
         const values = [userId, prefs];
-        const createUserPreferences = await client.query(
+        const createUserPreferences = await poolRef.query(
           insertUserPreferences,
           values
         );
@@ -61,8 +57,6 @@ export default class UserPreferencesDAO {
       }
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/usersDAO.js
+++ b/server/src/dao/usersDAO.js
@@ -22,7 +22,7 @@ export default class UsersDAO {
   static async getAllUsers() {
     try {
       client = await poolRef.connect();
-      const users = await client.query(allUsers);
+      const users = await poolRef.query(allUsers);
       return users.rows;
     } catch (err) {
       console.error(err.message);
@@ -32,16 +32,15 @@ export default class UsersDAO {
   }
   static async patchUser(userId, userDetails) {
     try {
-      client = await poolRef.connect();
       const dataArray = Object.keys(userDetails).map((col) => {
         return `${col} = '${userDetails[col]}'`;
       });
       const sqlParam = dataArray.join(', ');
       const rebuildQuery = `UPDATE ${process.env.DATABASE}.users SET ${sqlParam} WHERE id = $1`;
       // userDetails
-      const userExists = await client.query(getUser, [userId]);
+      const userExists = await poolRef.query(getUser, [userId]);
       if (userExists.rowCount > 0) {
-        const updateUser = await client.query(rebuildQuery, [userId]);
+        const updateUser = await poolRef.query(rebuildQuery, [userId]);
         return updateUser.rows;
       } else {
         const cannotFindUser = new Error('Cannot find user');
@@ -49,8 +48,6 @@ export default class UsersDAO {
       }
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/venuesDAO.js
+++ b/server/src/dao/venuesDAO.js
@@ -21,13 +21,10 @@ export default class VenuesDAO {
   }
   static async getAllVenues() {
     try {
-      client = await poolRef.connect();
-      const venues = await client.query(allVenues);
+      const venues = await poolRef.query(allVenues);
       return venues.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }

--- a/server/src/dao/versusDAO.js
+++ b/server/src/dao/versusDAO.js
@@ -28,8 +28,7 @@ export default class VersusDAO {
   }
   static async getVersusResults(player1Id, player2Id) {
     try {
-      client = await poolRef.connect();
-      const data = await client.query(`${query} ${pvp}`, [
+      const data = await poolRef.query(`${query} ${pvp}`, [
         player1Id,
         player2Id,
         player1Id,
@@ -38,8 +37,6 @@ export default class VersusDAO {
       return data.rows;
     } catch (err) {
       console.error(err.message);
-    } finally {
-      client.release();
     }
   }
 }


### PR DESCRIPTION
fix(BE): node-pg documentation recommends using pool.query rather than manually calling final -> release() as it will automatically handle release()

When quickly changing pages/versus players in the FE I was managing to crash the server
![image](https://user-images.githubusercontent.com/10856551/176795232-d3b9c246-61ff-45af-aeec-e644c4a7487c.png)


https://github.com/postgres-pool/postgres-pool#readme

![image](https://user-images.githubusercontent.com/10856551/176794929-1ebde3c2-4e30-464a-a834-e07e7429f03e.png)

![image](https://user-images.githubusercontent.com/10856551/176794982-7c252240-909b-432a-b0fe-316f7b17b27e.png)

Previously I was trying to 
`finally {
  pool.release()
}`